### PR TITLE
feat(#435) Get only firestations from user department

### DIFF
--- a/src/app/management-department/shared/services/firestation.service.ts
+++ b/src/app/management-department/shared/services/firestation.service.ts
@@ -13,7 +13,7 @@ export class FirestationService extends RequestService {
     }
 
     getAll(): Observable<Firestation[]> {
-        return this.get('Firestation/localized');
+        return this.get('Firestation/AvailableForManagement');
     }
 
     getAllOfCity(idCity: string): Observable<Firestation[]> {


### PR DESCRIPTION
Correction pour ne plus recevoir toutes les firestations, mais seulement celles qui font partie des SSI auxquels l'utilisateur a accès.